### PR TITLE
fix: very slow on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM rust:1.69.0-slim-buster AS build
-
 WORKDIR /app
 COPY . .
 RUN cargo build --release
 
-FROM centos:8
 
-# Copy the binary from the build stage to the current directory in the new stage
-COPY --from=build /app/target/release/enso-temper /enso-temper
-EXPOSE 80
-CMD ["./enso-temper"]
+FROM debian:buster-slim
+
+RUN apt-get update && apt-get install -y \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/target/release/enso-temper /usr/local/bin/enso-temper
+EXPOSE 8080
+
+CMD ["/usr/local/bin/enso-temper"]


### PR DESCRIPTION
Issue: Response return very slow when running on dockerfile (avg 6s instead 600ms)

Use debian as base intead of centos

![image](https://github.com/user-attachments/assets/85356ac0-1e14-4d88-8124-da21a9798c7b)

Test:

```
docker run -p 8080:8080 temper:0.1.0
```

```sh
curl --location 'localhost:8080/api/v1/simulate' \
--header 'Content-Type: application/json' \
--data '{
  "chainId": 1,
  "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
  "to": "0x66fc62c1748e45435b06cf8dd105b73e9855f93e",
  "data": "0xffa2ca3b44eea7c8e659973cbdf476546e9e6adfd1c580700537e52ba7124933a97904ea000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001d0e30db00300ffffffffffffc02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000186a0",
  "gasLimit": 500000,
  "value": "100000",
  "blockNumber": 16784600
}'
```


Response:
~ 600ms
![image](https://github.com/user-attachments/assets/981dcdda-9692-48a2-8602-07252adbebb5)
